### PR TITLE
fix: PowerShell 5.1 compatibility for Windows installer

### DIFF
--- a/vibe-local.ps1
+++ b/vibe-local.ps1
@@ -1,4 +1,4 @@
-# vibe-local.ps1
+﻿# vibe-local.ps1
 # Windows launcher for vibe-local
 # Uses vibe-coder.py directly — no proxy, no Node.js, no Claude Code needed
 #


### PR DESCRIPTION
## Summary

`install.ps1` fails on PowerShell 5.1 (the default PowerShell on Windows 10/11) due to three issues:

- **Missing UTF-8 BOM**: PS 5.1 reads `.ps1` files as Windows-1252 by default, garbling Japanese strings (`tagline` on line 51) and causing cascading parser errors
- **Invoke-RestMethod timeout**: PS 5.1 needs ~2s to initialize the .NET HTTP stack on the first call, causing `-TimeoutSec 2` to always time out. The Ollama health check loop runs 30s then fails even when Ollama is running
- **Ollama not found in PATH**: The Ollama GUI installer puts `ollama.exe` in `%LOCALAPPDATA%\Programs\Ollama\` which PS 5.1 can't find, triggering unnecessary winget reinstall

### Changes

1. Added UTF-8 BOM to `install.ps1` and `vibe-local.ps1`
2. Replaced `Invoke-RestMethod` with `Invoke-WebRequest -UseBasicParsing` (5s timeout) for Ollama health checks
3. Added fallback search of common Ollama install paths before winget install
4. Wrapped `Clear-Host` in try/catch to fix pwsh CursorPosition error
5. Added Ollama Windows service restart fallback

## Test plan

- [x] Syntax parse passes on PS 5.1 (`Parser::ParseFile`, zero errors)
- [x] Full `install.ps1` completes all 7 steps on PS 5.1.26100.7859
- [x] Full `install.ps1` completes all 7 steps on pwsh 7.5.4
- [x] Ollama detected without winget reinstall
- [x] No stderr errors on either PS version

Environment: Windows 11 Home (26220), PS 5.1.26100.7859, pwsh 7.5.4, Ollama 0.16.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)