### PR TITLE
Fix(docs): use Invoke-RestMethod in PowerShell install commands to prevent encoding issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ curl -fsSL https://raw.githubusercontent.com/ochyai/vibe-local/main/install.sh |
 
 *Windows (PowerShell) の場合:*
 ```powershell
-Invoke-WebRequest -Uri https://raw.githubusercontent.com/ochyai/vibe-local/main/install.ps1 -UseBasicParsing | Invoke-Expression
+Invoke-Expression (Invoke-RestMethod -Uri https://raw.githubusercontent.com/ochyai/vibe-local/main/install.ps1)
 ```
 
 **3.** 新しいターミナルを開いて起動:
@@ -153,7 +153,7 @@ curl -fsSL https://raw.githubusercontent.com/ochyai/vibe-local/main/install.sh |
 
 *Windows (PowerShell) のとき:*
 ```powershell
-Invoke-WebRequest -Uri https://raw.githubusercontent.com/ochyai/vibe-local/main/install.ps1 -UseBasicParsing | Invoke-Expression
+Invoke-Expression (Invoke-RestMethod -Uri https://raw.githubusercontent.com/ochyai/vibe-local/main/install.ps1)
 ```
 
 **3.** あたらしい ターミナルを ひらいて、これを うつ：
@@ -237,7 +237,7 @@ curl -fsSL https://raw.githubusercontent.com/ochyai/vibe-local/main/install.sh |
 
 *For Windows (PowerShell natively):*
 ```powershell
-Invoke-WebRequest -Uri https://raw.githubusercontent.com/ochyai/vibe-local/main/install.ps1 -UseBasicParsing | Invoke-Expression
+Invoke-Expression (Invoke-RestMethod -Uri https://raw.githubusercontent.com/ochyai/vibe-local/main/install.ps1)
 ```
 
 **3.** Open a new terminal and run:
@@ -341,7 +341,7 @@ curl -fsSL https://raw.githubusercontent.com/ochyai/vibe-local/main/install.sh |
 
 *Windows (PowerShell) 环境:*
 ```powershell
-Invoke-WebRequest -Uri https://raw.githubusercontent.com/ochyai/vibe-local/main/install.ps1 -UseBasicParsing | Invoke-Expression
+Invoke-Expression (Invoke-RestMethod -Uri https://raw.githubusercontent.com/ochyai/vibe-local/main/install.ps1)
 ```
 
 **3.** 打开新终端并运行：


### PR DESCRIPTION
Executing the install script via Invoke-WebRequest may results in corrupted text (mojibake). 

```powershell
Invoke-WebRequest -Uri https://raw.githubusercontent.com/ochyai/vibe-local/main/install.ps1 -UseBasicParsing | Invoke-Expression
# mojibake
```
<img width="1216" height="630" alt="image" src="https://github.com/user-attachments/assets/75d45e13-fc5e-48f0-8a1b-2b5ca6b9ce59" />

This appears to happen because when the Invoke-WebRequest object is passed through the pipeline, it gets affected by the system's default encoding (e.g., Shift-JIS), corrupting the UTF-8 characters before they reach Invoke-Expression.

I found that using Invoke-RestMethod instead of Invoke-WebRequest resolves this perfectly. irm correctly because it respects the HTTP header (charset=utf-8) and returns the string directly, avoiding the pipeline encoding issue.

I have confirmed that the following command works correctly on both PowerShell 5.1 and 7.5.4 in a Japanese environment:

```powershell
Invoke-Expression (Invoke-RestMethod -Uri https://raw.githubusercontent.com/ochyai/vibe-local/main/install.ps1)
# texts are displayed correctly
```

