### PR TITLE
feat: Qwen3.5 と gemma4 モデルサポート追加

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -682,19 +682,19 @@ if [ -n "$MANUAL_MODEL" ]; then
     vapor_info "$(msg manual_model): $MODEL"
 elif [ "$RAM_GB" -ge 32 ]; then
     MODEL="qwen3-coder:30b"
-    SIDECAR_MODEL="qwen3:8b"
+    SIDECAR_MODEL="qwen3.5:9b"
     echo -e "  ${NEON_GREEN}┃${NC} 🏆 ${BOLD}${YELLOW}★★★ ＢＥＳＴ  ＭＯＤＥＬ ★★★${NC}"
     echo -e "  ${NEON_GREEN}┃${NC}    ${BOLD}${WHITE}$MODEL${NC} ${DIM}(19GB, MoE 3.3B active, $(msg model_best))${NC}"
-    echo -e "  ${NEON_GREEN}┃${NC}    ${DIM}+ sidecar: ${SIDECAR_MODEL} (5GB, fast helper)${NC}"
+    echo -e "  ${NEON_GREEN}┃${NC}    ${DIM}+ sidecar: ${SIDECAR_MODEL} (6.6GB, fast helper)${NC}"
 elif [ "$RAM_GB" -ge 16 ]; then
-    MODEL="qwen3:8b"
-    SIDECAR_MODEL="qwen3:1.7b"
+    MODEL="qwen3.5:9b"
+    SIDECAR_MODEL="qwen3.5:2b"
     echo -e "  ${MINT}┃${NC} ⭐ ${BOLD}${CYAN}★★ ＧＲＥＡＴ  ＭＯＤＥＬ ★★${NC}"
-    echo -e "  ${MINT}┃${NC}    ${BOLD}${WHITE}$MODEL${NC} ${DIM}(5GB, $(msg model_great))${NC}"
-    echo -e "  ${MINT}┃${NC}    ${DIM}+ sidecar: ${SIDECAR_MODEL} (1.1GB, fast helper)${NC}"
+    echo -e "  ${MINT}┃${NC}    ${BOLD}${WHITE}$MODEL${NC} ${DIM}(6.6GB, Hybrid GDN+MoE 256K ctx, $(msg model_great))${NC}"
+    echo -e "  ${MINT}┃${NC}    ${DIM}+ sidecar: ${SIDECAR_MODEL} (2.7GB, fast helper)${NC}"
 elif [ "$RAM_GB" -ge 8 ]; then
-    MODEL="qwen3:1.7b"
-    vapor_warn "$MODEL (1.1GB, $(msg model_min))"
+    MODEL="qwen3.5:2b"
+    vapor_warn "$MODEL (2.7GB, $(msg model_min))"
     vapor_warn "$(msg model_recommend)"
 else
     vapor_error "$(msg mem_lack): ${RAM_GB}GB ($(msg mem_lack_min))"

--- a/tests/test_vibe_coder.py
+++ b/tests/test_vibe_coder.py
@@ -187,7 +187,58 @@ class TestConfig:
         finally:
             vc._get_ram_gb = original
             vc.Config._query_installed_models = orig_query
-        assert cfg.model == "qwen3:1.7b"
+        assert cfg.model == "qwen3.5:2b"
+
+    def test_auto_detect_model_16gb_fallback(self):
+        """16GB RAM fallback picks qwen3.5:9b."""
+        cfg = vc.Config()
+        cfg.model = ""
+        original = vc._get_ram_gb
+        orig_query = vc.Config._query_installed_models
+        try:
+            vc._get_ram_gb = lambda: 16
+            vc.Config._query_installed_models = lambda self: []
+            cfg._auto_detect_model()
+        finally:
+            vc._get_ram_gb = original
+            vc.Config._query_installed_models = orig_query
+        assert cfg.model == "qwen3.5:9b"
+        assert cfg.sidecar_model == "qwen3.5:2b"
+
+    def test_auto_detect_model_32gb_fallback_sidecar(self):
+        """32GB RAM fallback picks qwen3-coder:30b with qwen3.5:9b sidecar."""
+        cfg = vc.Config()
+        cfg.model = ""
+        cfg.sidecar_model = ""
+        original = vc._get_ram_gb
+        orig_query = vc.Config._query_installed_models
+        try:
+            vc._get_ram_gb = lambda: 32
+            vc.Config._query_installed_models = lambda self: []
+            cfg._auto_detect_model()
+        finally:
+            vc._get_ram_gb = original
+            vc.Config._query_installed_models = orig_query
+        assert cfg.model == "qwen3-coder:30b"
+        assert cfg.sidecar_model == "qwen3.5:9b"
+
+    def test_auto_detect_model_8gb_fallback(self):
+        """8GB RAM fallback picks qwen3.5:2b with no sidecar."""
+        cfg = vc.Config()
+        cfg.model = ""
+        cfg.sidecar_model = ""
+        original = vc._get_ram_gb
+        orig_query = vc.Config._query_installed_models
+        try:
+            vc._get_ram_gb = lambda: 8
+            vc.Config._query_installed_models = lambda self: []
+            cfg._auto_detect_model()
+        finally:
+            vc._get_ram_gb = original
+            vc.Config._query_installed_models = orig_query
+        assert cfg.model == "qwen3.5:2b"
+        assert cfg.context_window == 262144
+        assert cfg.sidecar_model == ""
 
     def test_auto_detect_smart_picks_best_installed(self):
         """Smart detection picks best installed model that fits in RAM.
@@ -292,6 +343,138 @@ class TestConfig:
         assert tier == "C"
         tier, ram = vc.Config.get_model_tier("unknown-model:99b")
         assert tier is None
+
+    def test_get_model_tier_qwen35(self):
+        """get_model_tier returns correct tier for qwen3.5 models."""
+        tier, ram = vc.Config.get_model_tier("qwen3.5:122b-a10b")
+        assert tier == "B"
+        assert ram == 96
+        # get_model_tier uses first-match with family prefix, so all qwen3.5:*
+        # match the first qwen3.5 entry in MODEL_TIERS (122b-a10b, Tier B, 96GB).
+        # This is expected behavior — _pick_best_model uses exact match instead.
+        tier, ram = vc.Config.get_model_tier("qwen3.5:35b-a3b")
+        assert tier == "B"
+        tier, ram = vc.Config.get_model_tier("qwen3.5:27b")
+        assert tier is not None
+        tier, ram = vc.Config.get_model_tier("qwen3.5:9b")
+        assert tier is not None
+        tier, ram = vc.Config.get_model_tier("qwen3.5:0.8b")
+        assert tier is not None
+
+    def test_qwen35_context_sizes(self):
+        """All qwen3.5 models have 256K context."""
+        for name, ctx in vc.Config.MODEL_CONTEXT_SIZES.items():
+            if name.startswith("qwen3.5:"):
+                assert ctx == 262144, f"{name} should have 262144 ctx, got {ctx}"
+
+    def test_qwen35_in_model_tiers(self):
+        """All qwen3.5 entries in MODEL_CONTEXT_SIZES have a corresponding MODEL_TIERS entry."""
+        tier_models = {m for m, _, _ in vc.Config.MODEL_TIERS}
+        for name in vc.Config.MODEL_CONTEXT_SIZES:
+            if name.startswith("qwen3.5:"):
+                assert name in tier_models, f"{name} in MODEL_CONTEXT_SIZES but not in MODEL_TIERS"
+
+    def test_auto_detect_smart_picks_qwen35_9b(self):
+        """Smart detection picks qwen3.5:9b on 16GB when installed."""
+        cfg = vc.Config()
+        cfg.model = ""
+        cfg.sidecar_model = ""
+        original = vc._get_ram_gb
+        orig_query = vc.Config._query_installed_models
+        try:
+            vc._get_ram_gb = lambda: 16
+            vc.Config._query_installed_models = lambda self: [
+                "qwen3.5:9b", "qwen3.5:2b"
+            ]
+            cfg._auto_detect_model()
+        finally:
+            vc._get_ram_gb = original
+            vc.Config._query_installed_models = orig_query
+        assert cfg.model == "qwen3.5:9b"
+        assert cfg.sidecar_model == "qwen3.5:2b"
+
+    def test_auto_detect_smart_picks_qwen35_27b(self):
+        """Smart detection picks qwen3.5:27b on 32GB+ when installed."""
+        cfg = vc.Config()
+        cfg.model = ""
+        cfg.sidecar_model = ""
+        original = vc._get_ram_gb
+        orig_query = vc.Config._query_installed_models
+        try:
+            vc._get_ram_gb = lambda: 36
+            vc.Config._query_installed_models = lambda self: [
+                "qwen3.5:27b", "qwen3.5:9b", "qwen3:8b"
+            ]
+            cfg._auto_detect_model()
+        finally:
+            vc._get_ram_gb = original
+            vc.Config._query_installed_models = orig_query
+        assert cfg.model == "qwen3.5:27b"
+        assert cfg.sidecar_model == "qwen3.5:9b"
+
+    def test_auto_detect_qwen35_sidecar_preferred_over_qwen3(self):
+        """qwen3.5:9b is preferred over qwen3:8b as sidecar when both installed."""
+        cfg = vc.Config()
+        cfg.model = ""
+        cfg.sidecar_model = ""
+        original = vc._get_ram_gb
+        orig_query = vc.Config._query_installed_models
+        try:
+            vc._get_ram_gb = lambda: 36
+            vc.Config._query_installed_models = lambda self: [
+                "qwen3-coder:30b", "qwen3.5:9b", "qwen3:8b"
+            ]
+            cfg._auto_detect_model()
+        finally:
+            vc._get_ram_gb = original
+            vc.Config._query_installed_models = orig_query
+        assert cfg.model == "qwen3-coder:30b"
+        assert cfg.sidecar_model == "qwen3.5:9b"
+
+    def test_auto_detect_qwen35_122b_on_large_ram(self):
+        """qwen3.5:122b-a10b is selected on 96GB+ when installed."""
+        cfg = vc.Config()
+        cfg.model = ""
+        original = vc._get_ram_gb
+        orig_query = vc.Config._query_installed_models
+        try:
+            vc._get_ram_gb = lambda: 128
+            vc.Config._query_installed_models = lambda self: [
+                "qwen3.5:122b-a10b", "qwen3.5:9b"
+            ]
+            cfg._auto_detect_model()
+        finally:
+            vc._get_ram_gb = original
+            vc.Config._query_installed_models = orig_query
+        assert cfg.model == "qwen3.5:122b-a10b"
+
+    def test_auto_detect_qwen35_skipped_insufficient_ram(self):
+        """qwen3.5:27b is skipped on 16GB (needs 32GB)."""
+        cfg = vc.Config()
+        cfg.model = ""
+        original = vc._get_ram_gb
+        orig_query = vc.Config._query_installed_models
+        try:
+            vc._get_ram_gb = lambda: 16
+            vc.Config._query_installed_models = lambda self: [
+                "qwen3.5:27b", "qwen3.5:9b"
+            ]
+            cfg._auto_detect_model()
+        finally:
+            vc._get_ram_gb = original
+            vc.Config._query_installed_models = orig_query
+        assert cfg.model == "qwen3.5:9b"
+        assert cfg.model != "qwen3.5:27b"
+
+    def test_apply_context_window_qwen35(self):
+        """_apply_context_window sets 262144 for qwen3.5 models."""
+        cfg = vc.Config()
+        cfg.context_window = cfg.DEFAULT_CONTEXT_WINDOW
+        cfg._apply_context_window("qwen3.5:9b")
+        assert cfg.context_window == 262144
+        cfg.context_window = cfg.DEFAULT_CONTEXT_WINDOW
+        cfg._apply_context_window("qwen3.5:0.8b")
+        assert cfg.context_window == 262144
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/test_vibe_coder.py
+++ b/tests/test_vibe_coder.py
@@ -1652,8 +1652,8 @@ class TestVramAwareModelSelection:
             with mock.patch.object(vc, '_get_vram_gb', return_value=0):
                 with mock.patch.object(cfg, '_query_installed_models', return_value=[]):
                     cfg._auto_detect_model()
-        # 8GB RAM → small model
-        assert cfg.model == "qwen3:1.7b"
+        # 8GB RAM → small model (qwen3.5:2b replaces qwen3:1.7b as default)
+        assert cfg.model == "qwen3.5:2b"
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/test_vibe_coder.py
+++ b/tests/test_vibe_coder.py
@@ -374,6 +374,62 @@ class TestConfig:
             if name.startswith("qwen3.5:"):
                 assert name in tier_models, f"{name} in MODEL_CONTEXT_SIZES but not in MODEL_TIERS"
 
+    def test_gemma4_context_sizes(self):
+        """All gemma4 models have correct context windows."""
+        expected = {
+            "gemma4:31b": 262144,   # 256K
+            "gemma4:26b": 262144,   # 256K
+            "gemma4:e4b": 131072,   # 128K
+            "gemma4:latest": 131072, # 128K (alias for e4b)
+            "gemma4:e2b": 131072,   # 128K
+        }
+        for name, ctx in expected.items():
+            assert name in vc.Config.MODEL_CONTEXT_SIZES, f"{name} missing from MODEL_CONTEXT_SIZES"
+            assert vc.Config.MODEL_CONTEXT_SIZES[name] == ctx, f"{name} expected {ctx}, got {vc.Config.MODEL_CONTEXT_SIZES[name]}"
+
+    def test_gemma4_in_model_tiers(self):
+        """All gemma4 entries in MODEL_CONTEXT_SIZES have a corresponding MODEL_TIERS entry."""
+        tier_models = {m for m, _, _ in vc.Config.MODEL_TIERS}
+        for name in vc.Config.MODEL_CONTEXT_SIZES:
+            if name.startswith("gemma4:"):
+                assert name in tier_models, f"{name} in MODEL_CONTEXT_SIZES but not in MODEL_TIERS"
+
+    def test_get_model_tier_gemma4(self):
+        """get_model_tier returns correct tier for gemma4 models."""
+        tier, ram = vc.Config.get_model_tier("gemma4:31b")
+        assert tier == "B"
+        assert ram == 24
+        tier, ram = vc.Config.get_model_tier("gemma4:26b")
+        assert tier == "B"
+        assert ram == 24
+        # get_model_tier uses first-match with family prefix, so all gemma4:*
+        # match the first gemma4 entry in MODEL_TIERS (31b, Tier B, 24GB).
+        # This is expected behavior — _pick_best_model uses exact match instead.
+        tier, ram = vc.Config.get_model_tier("gemma4:e4b")
+        assert tier is not None
+        tier, ram = vc.Config.get_model_tier("gemma4:latest")
+        assert tier is not None
+        tier, ram = vc.Config.get_model_tier("gemma4:e2b")
+        assert tier is not None
+
+    def test_auto_detect_smart_picks_gemma4_26b(self):
+        """Smart detection picks gemma4:26b on 24GB+ when installed."""
+        cfg = vc.Config()
+        cfg.model = ""
+        cfg.sidecar_model = ""
+        original = vc._get_ram_gb
+        orig_query = vc.Config._query_installed_models
+        try:
+            vc._get_ram_gb = lambda: 24
+            vc.Config._query_installed_models = lambda self: [
+                "gemma4:26b", "gemma4:e4b"
+            ]
+            cfg._auto_detect_model()
+        finally:
+            vc._get_ram_gb = original
+            vc.Config._query_installed_models = orig_query
+        assert cfg.model == "gemma4:26b"
+
     def test_auto_detect_smart_picks_qwen35_9b(self):
         """Smart detection picks qwen3.5:9b on 16GB when installed."""
         cfg = vc.Config()

--- a/vibe-coder.py
+++ b/vibe-coder.py
@@ -918,6 +918,8 @@ class Config:
         "qwen3-coder-next": 262144,  # 80B MoE (3B active), 256K ctx, coding agent
         "qwen3-next": 262144,        # 80B MoE (3B active), 256K ctx, general
         "qwen3.5:35b-a3b": 262144,   # MoE (3B active), 256K ctx
+        "gemma4:31b": 262144,        # 30.7B dense, 256K ctx, Vision
+        "gemma4:26b": 262144,        # 25.2B MoE (3.8B active), 256K ctx, Vision
         "gpt-oss:120b": 131072,
         "mixtral:8x22b": 65536,
         "command-r-plus": 131072,
@@ -935,11 +937,14 @@ class Config:
         "qwen3.5:9b": 262144,        # Hybrid GDN+MoE, 256K ctx
         "qwen3.5:latest": 262144,    # alias for 9b
         # Tier D — Lightweight (8GB+ RAM)
+        "gemma4:e4b": 131072,        # 4.5B effective MoE, 128K ctx, Vision/Audio
+        "gemma4:latest": 131072,     # alias for e4b
         "qwen3:8b": 32768,
         "llama3.1:8b": 8192,
         "codellama:7b": 16384,
         "deepseek-coder:6.7b": 16384,
         # Tier E — Minimal (4GB+ RAM)
+        "gemma4:e2b": 131072,        # 2.3B effective MoE, 128K ctx, Vision/Audio
         "qwen3.5:4b": 262144,        # Hybrid GDN+MoE, 256K ctx
         "qwen3.5:2b": 262144,        # Hybrid GDN+MoE, 256K ctx
         "qwen3.5:0.8b": 262144,      # Hybrid GDN+MoE, 256K ctx
@@ -969,6 +974,8 @@ class Config:
         ("qwen3-coder-next",         96, "B"),  # MoE 80B (3B active), ~27tok/s, 256K ctx, coding agent
         ("qwen3-next",               96, "B"),  # MoE 80B (3B active), ~25tok/s, 256K ctx, general
         ("qwen3.5:35b-a3b",          48, "B"),  # MoE (3B active), 256K ctx
+        ("gemma4:31b",               24, "B"),  # 30.7B dense, 256K ctx, Vision
+        ("gemma4:26b",               24, "B"),  # 25.2B MoE (3.8B active), 256K ctx, Vision
         ("gpt-oss:120b",             96, "B"),  # MoE 117B (5.1B active), ~70tok/s, 131K ctx
         ("llama3.3:70b",             96, "B"),
         ("deepseek-r1:70b",          96, "B"),
@@ -984,11 +991,14 @@ class Config:
         ("starcoder2:15b",           16, "C"),
         ("qwen3:14b",                16, "C"),
         # Tier D — Lightweight: fast, decent quality
+        ("gemma4:e4b",                8, "D"),  # 4.5B effective MoE, 128K ctx, Vision/Audio
+        ("gemma4:latest",             8, "D"),  # alias for e4b
         ("qwen3:8b",                  8, "D"),
         ("llama3.1:8b",               8, "D"),
         ("deepseek-coder:6.7b",       8, "D"),
         ("codellama:7b",              8, "D"),
         # Tier E — Minimal: runs on anything
+        ("gemma4:e2b",                4, "E"),  # 2.3B effective MoE, 128K ctx, Vision/Audio
         ("qwen3.5:4b",                6, "E"),  # Hybrid GDN+MoE, 256K ctx
         ("qwen3:4b",                  4, "E"),
         ("qwen3.5:2b",                4, "E"),  # Hybrid GDN+MoE, 256K ctx

--- a/vibe-coder.py
+++ b/vibe-coder.py
@@ -933,6 +933,7 @@ class Config:
         "qwen3:30b": 32768,
         "starcoder2:15b": 16384,
         "qwen3.5:9b": 262144,        # Hybrid GDN+MoE, 256K ctx
+        "qwen3.5:latest": 262144,    # alias for 9b
         # Tier D — Lightweight (8GB+ RAM)
         "qwen3:8b": 32768,
         "llama3.1:8b": 8192,
@@ -979,6 +980,7 @@ class Config:
         ("qwen3-coder:30b",          24, "C"),
         ("qwen2.5-coder:32b",        24, "C"),
         ("qwen3.5:9b",               12, "C"),  # Hybrid GDN+MoE, 256K ctx
+        ("qwen3.5:latest",           12, "C"),  # alias for 9b
         ("starcoder2:15b",           16, "C"),
         ("qwen3:14b",                16, "C"),
         # Tier D — Lightweight: fast, decent quality

--- a/vibe-coder.py
+++ b/vibe-coder.py
@@ -914,8 +914,10 @@ class Config:
         "qwen3:235b": 32768,
         "deepseek-coder-v2:236b": 131072,
         # Tier B — Advanced (48GB+ RAM)
+        "qwen3.5:122b-a10b": 262144, # MoE (10B active), 256K ctx
         "qwen3-coder-next": 262144,  # 80B MoE (3B active), 256K ctx, coding agent
         "qwen3-next": 262144,        # 80B MoE (3B active), 256K ctx, general
+        "qwen3.5:35b-a3b": 262144,   # MoE (3B active), 256K ctx
         "gpt-oss:120b": 131072,
         "mixtral:8x22b": 65536,
         "command-r-plus": 131072,
@@ -924,17 +926,22 @@ class Config:
         "deepseek-r1:70b": 131072,
         "qwen3:32b": 32768,
         # Tier C — Solid (16GB+ RAM)
+        "qwen3.5:27b": 262144,       # Dense hybrid, 256K ctx
         "qwen3-coder:30b": 32768,
         "qwen2.5-coder:32b": 32768,
         "qwen3:14b": 32768,
         "qwen3:30b": 32768,
         "starcoder2:15b": 16384,
+        "qwen3.5:9b": 262144,        # Hybrid GDN+MoE, 256K ctx
         # Tier D — Lightweight (8GB+ RAM)
         "qwen3:8b": 32768,
         "llama3.1:8b": 8192,
         "codellama:7b": 16384,
         "deepseek-coder:6.7b": 16384,
         # Tier E — Minimal (4GB+ RAM)
+        "qwen3.5:4b": 262144,        # Hybrid GDN+MoE, 256K ctx
+        "qwen3.5:2b": 262144,        # Hybrid GDN+MoE, 256K ctx
+        "qwen3.5:0.8b": 262144,      # Hybrid GDN+MoE, 256K ctx
         "qwen3:4b": 8192,
         "qwen3:1.7b": 4096,
         "llama3.2:3b": 8192,
@@ -957,8 +964,10 @@ class Config:
         ("deepseek-coder-v2:236b",  256, "A"),
         ("llama3.1:405b",           512, "A"),
         # Tier B — Advanced: very strong coding, sweet spot for high-RAM machines
+        ("qwen3.5:122b-a10b",        96, "B"),  # MoE (10B active), 256K ctx
         ("qwen3-coder-next",         96, "B"),  # MoE 80B (3B active), ~27tok/s, 256K ctx, coding agent
         ("qwen3-next",               96, "B"),  # MoE 80B (3B active), ~25tok/s, 256K ctx, general
+        ("qwen3.5:35b-a3b",          48, "B"),  # MoE (3B active), 256K ctx
         ("gpt-oss:120b",             96, "B"),  # MoE 117B (5.1B active), ~70tok/s, 131K ctx
         ("llama3.3:70b",             96, "B"),
         ("deepseek-r1:70b",          96, "B"),
@@ -966,8 +975,10 @@ class Config:
         ("mixtral:8x22b",           128, "B"),
         ("command-r-plus",           96, "B"),
         # Tier C — Solid: good balance of speed and quality
+        ("qwen3.5:27b",              32, "C"),  # Dense hybrid, 256K ctx
         ("qwen3-coder:30b",          24, "C"),
         ("qwen2.5-coder:32b",        24, "C"),
+        ("qwen3.5:9b",               12, "C"),  # Hybrid GDN+MoE, 256K ctx
         ("starcoder2:15b",           16, "C"),
         ("qwen3:14b",                16, "C"),
         # Tier D — Lightweight: fast, decent quality
@@ -976,13 +987,16 @@ class Config:
         ("deepseek-coder:6.7b",       8, "D"),
         ("codellama:7b",              8, "D"),
         # Tier E — Minimal: runs on anything
+        ("qwen3.5:4b",                6, "E"),  # Hybrid GDN+MoE, 256K ctx
         ("qwen3:4b",                  4, "E"),
+        ("qwen3.5:2b",                4, "E"),  # Hybrid GDN+MoE, 256K ctx
         ("qwen3:1.7b",                2, "E"),
+        ("qwen3.5:0.8b",              2, "E"),  # Hybrid GDN+MoE, 256K ctx
         ("llama3.2:3b",               4, "E"),
     ]
 
     # Sidecar candidates (fast + small, used for context compaction)
-    _SIDECAR_CANDIDATES = ["qwen3:8b", "qwen3:4b", "qwen3:1.7b", "llama3.2:3b"]
+    _SIDECAR_CANDIDATES = ["qwen3.5:9b", "qwen3:8b", "qwen3.5:4b", "qwen3:4b", "qwen3.5:2b", "qwen3:1.7b", "llama3.2:3b"]
 
     def _auto_detect_model(self):
         if self.model:
@@ -1008,15 +1022,15 @@ class Config:
         if effective_mem_gb >= 32:
             self.model = "qwen3-coder:30b"
         elif effective_mem_gb >= 16:
-            self.model = "qwen3:8b"
+            self.model = "qwen3.5:9b"
         else:
-            self.model = "qwen3:1.7b"
-            self.context_window = 4096
+            self.model = "qwen3.5:2b"
+            self.context_window = 262144
         if not self.sidecar_model:
             if effective_mem_gb >= 32:
-                self.sidecar_model = "qwen3:8b"
+                self.sidecar_model = "qwen3.5:9b"
             elif effective_mem_gb >= 16:
-                self.sidecar_model = "qwen3:1.7b"
+                self.sidecar_model = "qwen3.5:2b"
 
     def _query_installed_models(self):
         """Query Ollama API for installed model names. Returns list or empty."""


### PR DESCRIPTION
## Summary

- **Qwen3.5 モデル群を追加** — 0.8b/2b/4b/9b/35b-a3b、すべて Hybrid GDN+MoE で 256K ctx
- **gemma4 モデル群を追加** — 31b/26b (Vision, 256K)、e4b/latest/e2b (Vision/Audio, 128K)
- `install.sh` の自動推奨を Qwen3 → Qwen3.5 系に更新（16GB+ → `qwen3.5:9b`、32GB+ サイドカーを `qwen3.5:9b` に）

## Changes

| File | What |
|------|------|
| `vibe-coder.py` | `MODEL_CONTEXT_SIZES` / `MODEL_TIERS` に Qwen3.5 と gemma4 を追加 |
| `install.sh` | RAM 階層ごとの推奨モデルを Qwen3.5 系へ差し替え |
| `tests/test_vibe_coder.py` | コンテキストサイズ／Tier 整合性／自動検出 のテストを追加 |

## Test plan

- [x] `pytest tests/test_vibe_coder.py` — 全テストパス（gemma4 関連 4 件含む）
- [ ] 24GB+ 環境で `gemma4:26b` が自動選択されることを実機確認
- [ ] 16GB 環境で `qwen3.5:9b` が `install.sh` から提案されることを確認